### PR TITLE
FIX: Change release_sync.yml workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: Netlogix Release Bot
+    outputs:
+      release_bot_token: ${{ steps.release-bot-app-token.outputs.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -34,3 +36,11 @@ jobs:
         id: semantic   # Need an `id` for output variables
         env:
           GITHUB_TOKEN: ${{ steps.release-bot-app-token.outputs.token }}
+
+  sync-to-develop:
+    needs: release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release_sync.yml
+    secrets:
+      token: ${{ needs.release.outputs.release_bot_token }}

--- a/.github/workflows/release_sync.yml
+++ b/.github/workflows/release_sync.yml
@@ -1,9 +1,10 @@
 name: Sync release artifacts to develop
 
 on:
-  workflow_run:
-    workflows: ["Create release"]
-    types: [completed]
+  workflow_call:
+    secrets:
+      token:
+        required: true
 
 permissions:
   contents: write
@@ -12,23 +13,15 @@ permissions:
 
 jobs:
   sync-to-develop:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     environment: Netlogix Release Bot
 
     steps:
-      - name: Create GitHub App token
-        uses: actions/create-github-app-token@v3
-        id: release-bot-app-token
-        with:
-          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-
       - name: Checkout (full history)
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ steps.release-bot-app-token.outputs.token }}
+          token: ${{ secrets.token }}
 
       - name: Configure git & auth
         run: |
@@ -84,7 +77,7 @@ jobs:
           echo "nothing_to_sync=false" >> "$GITHUB_OUTPUT"
           echo "done"
         env:
-          GITHUB_TOKEN: ${{ steps.release-bot-app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.token }}
 
       - name: Done
         if: steps.sync.outputs.nothing_to_sync == 'true'


### PR DESCRIPTION
Define release_sync.yml as workflow_call to run the workflow in "main" context from release.yml. Otherwise we cannot use environment variables from "Netlogix Release Bot"

Related: SHOPWARE-222