### PR TITLE
FEAT: Move storefront to requrei to pass shopware static code analysis

### DIFF
--- a/.github/workflows/upmerge.yml
+++ b/.github/workflows/upmerge.yml
@@ -5,18 +5,11 @@ on:
     branches:
       - develop
 
-permissions:
-  contents: write
-  packages: read
-
 jobs:
   upmerge:
-
     runs-on: ubuntu-latest
-
     env:
       GH_TOKEN: ${{ github.token }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
     ],
     "require": {
         "php": ">=8.2",
-        "shopware/core": "~6.7.1"
+        "shopware/core": "~6.7.1",
+        "shopware/storefront": "*"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.47",
         "netlogix/coding-guidelines-php": "^1.0",
         "phpunit/phpunit": "^11.0",
         "rector/rector": "^2.1",
-        "shopware/storefront": "*",
         "shopwarelabs/phpstan-shopware": "^0.1.14"
     },
     "autoload": {


### PR DESCRIPTION
Shopware runs phpstan without dev and therefore the UrlEncodingTwigFilter class not exists. This class is needed here src/Decorator/UrlEncodingTwigFilterDecorator.php.

Error from the phpstan:

Warnings of the static code analysis:

---------------------------------------------------------------------------
     Error
 -- ---------------------------------------------------------------------------
     Internal error: Class
     Shopware\Storefront\Framework\Twig\Extension\UrlEncodingTwigFilter was
     not found while trying to analyse it - discovering symbols is probably
     not configured properly. while analysing file
     /tmp/plugincheck/NlxSwImgproxy/src/Decorator/UrlEncodingTwigFilterDecorat
     or.php

     Run PHPStan with -v option and post the stack trace to:
     https://github.com/phpstan/phpstan/issues/new?template=Bug_report.yaml

 -- ---------------------------------------------------------------------------

 [ERROR] Found 1 error

⚠️  Result is incomplete because of severe errors. ⚠️
   Fix these errors first and then re-run PHPStan
   to get all reported errors.